### PR TITLE
Fix CI workflow failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
         fail_ci_if_error: false
         verbose: true
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -72,7 +72,7 @@ jobs:
       uses: trufflesecurity/trufflehog@main
       with:
         path: ./
-        base: main
+        base: ${{ github.event.repository.default_branch }}
         head: HEAD
         extra_args: --debug --only-verified
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,7 +136,8 @@ class TestConfig:
         try:
             os.environ["SSDOWNLOAD_CACHE_DIR"] = test_cache_dir
             cache_dir = Config.get_default_cache_dir()
-            assert str(cache_dir) == test_cache_dir
+            # Convert both to Path objects to handle cross-platform path separators
+            assert Path(str(cache_dir)) == Path(test_cache_dir)
         finally:
             # Restore original environment
             if original_env is not None:


### PR DESCRIPTION
## Summary
Fix three CI workflow issues that were causing test failures:

- **Windows test failure**: Fixed cross-platform path comparison in cache directory test
- **Codecov configuration error**: Removed invalid 'file' parameter from codecov action
- **TruffleHog security scan issue**: Use dynamic default branch reference instead of hardcoded 'main'

## Changes Made
1. **tests/test_config.py**: Use `Path` objects for cross-platform path comparison
2. **.github/workflows/ci.yml**: Remove `file` parameter from codecov action 
3. **.github/workflows/security.yml**: Use `${{ github.event.repository.default_branch }}` for TruffleHog base

## Test Plan
- [x] Local test passes for path comparison fix
- [x] Ruff formatting and linting pass
- [x] CI workflows should now pass on all platforms
- [x] Security scans should complete without BASE/HEAD commit errors

🤖 Generated with [Claude Code](https://claude.ai/code)