### PR TITLE
Fix TruffleHog security scan BASE=HEAD error

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -68,12 +68,29 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Run TruffleHog OSS
+    - name: Run TruffleHog OSS (Pull Request)
+      if: github.event_name == 'pull_request'
       uses: trufflesecurity/trufflehog@main
       with:
         path: ./
-        base: ${{ github.event.repository.default_branch }}
-        head: HEAD
+        base: ${{ github.event.pull_request.base.sha }}
+        head: ${{ github.event.pull_request.head.sha }}
+        extra_args: --debug --only-verified
+
+    - name: Run TruffleHog OSS (Push)
+      if: github.event_name == 'push'
+      uses: trufflesecurity/trufflehog@main
+      with:
+        path: ./
+        base: ${{ github.event.before }}
+        head: ${{ github.event.after }}
+        extra_args: --debug --only-verified
+
+    - name: Run TruffleHog OSS (Full Scan)
+      if: github.event_name != 'pull_request' && github.event_name != 'push'
+      uses: trufflesecurity/trufflehog@main
+      with:
+        path: ./
         extra_args: --debug --only-verified
 
   dependency-review:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .ruff_cache/
 .venv/
 test_output/
+matrices
 **/__pycache__/
 *.pyc
 *.pyo


### PR DESCRIPTION
## Summary
Fix TruffleHog security scan that was failing with "BASE and HEAD commits are the same" error.

## Problem
TruffleHog was configured with a single approach that didn't work properly for different GitHub event types:
- Push events: `github.event.repository.default_branch` and `HEAD` were the same
- This caused the scan to exit with error code 1

## Solution
Implement event-specific TruffleHog configurations:

### 🔍 **Pull Request Events**
- Base: `${{ github.event.pull_request.base.sha }}`
- Head: `${{ github.event.pull_request.head.sha }}`
- Scans only the diff between PR base and head

### 📤 **Push Events** 
- Base: `${{ github.event.before }}`
- Head: `${{ github.event.after }}`
- Scans only the pushed commits

### 🔄 **Other Events** (schedule, workflow_dispatch)
- No base/head specified
- Performs full repository scan

## Test Plan
- [x] Configuration updated for all event types
- [ ] Push events should no longer fail with BASE=HEAD error
- [ ] PR events should scan only changed files
- [ ] Scheduled scans should scan entire repository

## References
- [TruffleHog GitHub Action Documentation](https://github.com/trufflesecurity/trufflehog#octocat-trufflehog-github-action)
- [GitHub Events Documentation](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads)

🤖 Generated with [Claude Code](https://claude.ai/code)