### PR TITLE
docs: recommend uv tool install as primary CLI setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,15 +136,19 @@ jobs:
 
           ## Installation
 
+          CLI (recommended):
+
+          ```bash
+          uv tool install ssdownload==${{ github.ref_name }}
+          ```
+
+          Python library:
+
           ```bash
           pip install ssdownload==${{ github.ref_name }}
           ```
 
-          or
-
-          ```bash
-          uv add ssdownload==${{ github.ref_name }}
-          ```
+          See [Installation Guide](https://github.com/${{ github.repository }}/blob/main/docs/INSTALLATION.md).
 
           ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🔄 Changed
+- Installation docs now recommend `uv tool install ssdownload` as the primary CLI setup; removed outdated PyPI-unpublished and `uvx` quick-start guidance
+- GitHub Release notes list `uv tool install` for CLI installs
+
 ### ✨ Added
 - **🆕 NEW**: System-wide cache directory support using platformdirs
   - 📁 Cache files now stored in OS-appropriate locations (e.g., `~/.cache/ssdownload/` on Linux/macOS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔄 Changed
 - Installation docs now recommend `uv tool install ssdownload` as the primary CLI setup; removed outdated PyPI-unpublished and `uvx` quick-start guidance
 - GitHub Release notes list `uv tool install` for CLI installs
+- Installation docs note that a new terminal is required after `uv tool update-shell` before `ssdl` is on PATH
 
 ### ✨ Added
 - **🆕 NEW**: System-wide cache directory support using platformdirs

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Requires [uv](https://docs.astral.sh/uv/getting-started/installation/).
 ```bash
 uv tool install ssdownload
 uv tool update-shell   # First time only, if ssdl is not on PATH
+# Open a new terminal so PATH changes apply
 ssdl info ct20stif
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,41 +17,17 @@ A command-line tool and Python library that makes it easy to discover, download,
 
 ## 🚀 Quick Start
 
-```bash
-uvx --from ssdownload ssdl -h
-```
-
-The CLI is exposed via `uvx`, so you can reach it without a prior tool install.
-
-### Installation
+Requires [uv](https://docs.astral.sh/uv/getting-started/installation/).
 
 ```bash
-# Clone and install (not yet on PyPI)
-git clone <repository-url>
-cd ssdownload
-curl -LsSf https://astral.sh/uv/install.sh | sh  # Install uv
-uv sync                                           # Install dependencies
+uv tool install ssdownload
+uv tool update-shell   # First time only, if ssdl is not on PATH
+ssdl info ct20stif
 ```
 
-#### Global Installation (Recommended for Development)
-
-For easier command usage without `uv run` prefix:
-
-```bash
-# From project root (or use absolute path)
-uv tool install .          # Initial installation
-uv tool update-shell       # Update PATH (first time only)
-
-# Verify installation
-ssdl --help
-
-# After code changes
-uv tool upgrade ssdownload --reinstall   # Update wrapper only
-```
+See the [Installation Guide](docs/INSTALLATION.md) for details. To hack on the project, see the [Development Guide](docs/DEVELOPMENT.md).
 
 ### Basic Usage
-
-> **Command Format**: Use `ssdl` directly if you've done global installation, otherwise add `uv run` prefix.
 
 ```bash
 # Get matrix information

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -4,12 +4,9 @@ Complete command-line interface reference for the SuiteSparse Matrix Collection 
 
 ## Command Usage
 
-This reference shows commands using the global installation format (`ssdl`). If you're using development installation with uv, prefix all commands with `uv run`:
+Commands use the `ssdl` CLI after `uv tool install ssdownload` (see [Installation Guide](INSTALLATION.md)).
 
-- **Global installation**: `ssdl download ct20stif`
-- **Development with uv**: `uv run ssdl download ct20stif`
-
-See [Installation Guide](INSTALLATION.md) for setup instructions.
+When developing from a git clone, prefix commands with `uv run`, for example `uv run ssdl download ct20stif`.
 
 ## Commands Overview
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -49,22 +49,19 @@ uv run pytest
 uv run ssdl --help
 ```
 
-### Global Installation for Development
+### CLI installation for development
 
-For convenient CLI testing without `uv run` prefix:
+For convenient CLI testing without the `uv run` prefix:
 
 ```bash
-# Install globally for easy testing
-uv tool install .
+uv tool install -e .
 
-# Verify installation
 ssdl --help
 
 # After making code changes
 uv tool upgrade ssdownload --reinstall
 
-# Test changes immediately
-ssdl download ct20stif  # No need for uv run
+ssdl download ct20stif
 ```
 
 ### Alternative: pip setup

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -2,19 +2,15 @@
 
 Comprehensive examples for using the SuiteSparse Matrix Collection Downloader.
 
-## Command Format Note
+## Command format
 
-Examples are shown in both formats:
-- **Global installation** (recommended): `ssdl command`
-- **Development with uv**: `uv run ssdl command`
-
-Choose the format that matches your installation method.
+Examples use `ssdl` after `uv tool install ssdownload` ([Installation Guide](INSTALLATION.md)). When working from a git clone, use `uv run ssdl` instead (see [Development Guide](DEVELOPMENT.md)).
 
 ## Basic CLI Examples
 
 ### Single Matrix Downloads
 
-#### Global Installation
+#### Installed CLI
 ```bash
 # Download by name (auto-detects group)
 ssdl download ct20stif
@@ -33,7 +29,7 @@ ssdl download ct20stif --output ./my_matrices
 ssdl download ct20stif --verify
 ```
 
-#### Development with uv
+#### From source
 ```bash
 # Download by name (auto-detects group)
 uv run ssdl download ct20stif
@@ -54,7 +50,7 @@ uv run ssdl download ct20stif --verify
 
 ### Matrix Information and Search
 
-#### Global Installation
+#### Installed CLI
 ```bash
 # Get matrix details
 ssdl info ct20stif
@@ -72,7 +68,7 @@ ssdl list --spd --field real --verbose
 ssdl list --name "stif" --limit 3
 ```
 
-#### Development with uv
+#### From source
 ```bash
 # Get matrix details
 uv run ssdl info ct20stif
@@ -92,7 +88,7 @@ uv run ssdl list --name "stif" --limit 3
 
 ### Bulk Downloads
 
-#### Global Installation
+#### Installed CLI
 ```bash
 # Download SPD matrices
 ssdl bulk --spd --max-files 5
@@ -107,7 +103,7 @@ ssdl bulk --group "Boeing" --group "HB" --max-files 15
 ssdl bulk --field real --size 5000:50000 --nnz :100000 --max-files 20
 ```
 
-#### Development with uv
+#### From source
 ```bash
 # Download SPD matrices
 uv run ssdl bulk --spd --max-files 5

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,247 +1,64 @@
 # Installation Guide
 
-This guide covers all installation methods for the SuiteSparse Matrix Collection Downloader.
+How to install the SuiteSparse Matrix Collection Downloader CLI.
 
 ## Prerequisites
 
-- **Python 3.12+** - Required for full compatibility
-- **uv** (recommended) or **pip** for package management
+- **Python 3.12+**
+- **[uv](https://docs.astral.sh/uv/getting-started/installation/)** — install and update uv using the official documentation
 
-## Development Installation (Current)
-
-> **Note**: This package is currently in development and not yet published to PyPI.
-
-### Option 1: Using uv (Recommended)
+## Install the CLI
 
 ```bash
-# 1. Clone the repository
-git clone <repository-url>
-cd ssdownload
-
-# 2. Install uv if you haven't already
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# 3. Install dependencies and set up development environment
-uv sync
-
-# 4. Test the installation
-uv run ssdl --help
-```
-
-#### Global Installation with uv tool
-
-For convenient CLI usage without the `uv run` prefix:
-
-```bash
-# From project root directory
-uv tool install .          # Install globally
-uv tool update-shell       # Update PATH (first time only)
-
-# Verify global installation
-ssdl --help
-
-# After code changes (development)
-uv tool upgrade ssdownload --reinstall   # Update wrapper
-```
-
-**Benefits:**
-- No need to type `uv run` prefix
-- Works from any directory
-- Better user experience for frequent CLI usage
-
-### Option 2: Using pip
-
-```bash
-# 1. Clone the repository
-git clone <repository-url>
-cd ssdownload
-
-# 2. Create a virtual environment (recommended)
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-
-# 3. Install in development mode
-pip install -e ".[dev]"
-
-# 4. Test the installation
+uv tool install ssdownload
+uv tool update-shell   # First time only, if ssdl is not on PATH
 ssdl --help
 ```
 
-## Future PyPI Installation
+The CLI is installed in an isolated tool environment (similar to pipx), not into your system Python site-packages.
 
-Once published to PyPI, installation will be simplified to:
+Upgrade after a new release:
 
 ```bash
-# Standard installation
-pip install ssdownload
-
-# With development dependencies
-pip install ssdownload[dev]
+uv tool upgrade ssdownload
 ```
+
+## Verify
+
+```bash
+ssdl --help
+ssdl groups
+ssdl info ct20stif
+```
+
+## Development
+
+To work from a git clone, see the [Development Guide](DEVELOPMENT.md).
 
 ## Configuration
 
-### Environment Variables
+### Environment variables
 
-Set `SSDOWNLOAD_CACHE_DIR` to change the default cache directory:
+Set `SSDOWNLOAD_CACHE_DIR` to override the default cache location:
 
 ```bash
 export SSDOWNLOAD_CACHE_DIR=/path/to/cache
 ```
 
-### Cache Directory
+On Windows (PowerShell):
 
-By default, matrices are downloaded to the current working directory. You can specify custom directories:
+```powershell
+$env:SSDOWNLOAD_CACHE_DIR = "C:\path\to\cache"
+```
+
+### Download directory
+
+By default, matrix files are written under the current working directory unless you pass `--output`:
 
 ```bash
-# CLI: specify output directory for single command
 ssdl download ct20stif --output ./my_matrices
-
-# Environment variable: applies to all commands
-export SSDOWNLOAD_CACHE_DIR=./my_matrices
-ssdl download ct20stif
-```
-
-## Verification
-
-Test your installation with these commands:
-
-### With uv run (Development)
-```bash
-# Check CLI is working
-uv run ssdl --help
-
-# Test basic functionality
-uv run ssdl groups  # List available matrix groups
-
-# Test download (small file)
-uv run ssdl info ct20stif  # Get matrix information
-```
-
-### With Global Installation
-```bash
-# Check CLI is working
-ssdl --help
-
-# Test basic functionality
-ssdl groups  # List available matrix groups
-
-# Test download (small file)
-ssdl info ct20stif  # Get matrix information
-```
-
-## Development Setup
-
-If you plan to contribute to the project:
-
-```bash
-# Install with development dependencies
-uv sync  # Installs all dev dependencies
-
-# Install pre-commit hooks
-uv run pre-commit install
-
-# Run tests to verify setup
-uv run pytest
-
-# Check code quality tools
-uv run ruff check src tests
-uv run mypy src
 ```
 
 ## Troubleshooting
 
-### Python Version Issues
-
-```bash
-# Check Python version
-python --version  # Should be 3.12+
-
-# If using pyenv
-pyenv install 3.12
-pyenv local 3.12
-```
-
-### uv Installation Issues
-
-```bash
-# Manual uv installation
-pip install uv
-
-# Alternative installation methods
-# See: https://docs.astral.sh/uv/getting-started/installation/
-```
-
-### Permission Issues
-
-```bash
-# If you get permission errors
-pip install --user -e .
-
-# Or use virtual environment
-python -m venv venv
-source venv/bin/activate
-pip install -e .
-```
-
-### Network Issues
-
-If you're behind a corporate firewall:
-
-```bash
-# Configure pip/uv to use your proxy
-export HTTPS_PROXY=https://your-proxy:port
-export HTTP_PROXY=http://your-proxy:port
-
-# Or configure in pip.conf/uv.toml
-```
-
-## Advanced Configuration
-
-### Custom Downloader Settings
-
-```python
-from ssdownload import SuiteSparseDownloader
-
-# Custom configuration
-downloader = SuiteSparseDownloader(
-    cache_dir="./matrices",     # Custom cache directory
-    workers=8,                  # Max concurrent downloads
-    timeout=120.0,              # HTTP timeout in seconds
-    verify_checksums=True       # Enable MD5 verification
-)
-```
-
-### Integration with Jupyter
-
-```bash
-# Install Jupyter support
-uv add jupyter ipykernel
-
-# Use in notebooks
-import asyncio
-from ssdownload import SuiteSparseDownloader
-
-downloader = SuiteSparseDownloader()
-path = await downloader.download_by_name("ct20stif")
-```
-
-## Docker Installation
-
-If you prefer containerized deployment:
-
-```dockerfile
-FROM python:3.12-slim
-
-WORKDIR /app
-COPY . .
-
-RUN pip install uv && uv sync
-CMD ["uv", "run", "ssdl", "--help"]
-```
-
-```bash
-# Build and run
-docker build -t ssdownload .
-docker run -v $(pwd)/matrices:/app/matrices ssdownload uv run ssdl download ct20stif
-```
+See [Troubleshooting Guide](TROUBLESHOOTING.md). For `ssdl: command not found`, run `uv tool update-shell` and open a new terminal.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -12,8 +12,11 @@ How to install the SuiteSparse Matrix Collection Downloader CLI.
 ```bash
 uv tool install ssdownload
 uv tool update-shell   # First time only, if ssdl is not on PATH
+# Open a new terminal so PATH changes apply (same shell: exec "$SHELL")
 ssdl --help
 ```
+
+`uv tool update-shell` edits your shell startup files; it does not update the current session. After the first install, open a new terminal before running `ssdl`.
 
 The CLI is installed in an isolated tool environment (similar to pipx), not into your system Python site-packages.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -29,32 +29,29 @@ sudo apt update && sudo apt install python3.12  # Ubuntu
 brew install python@3.12                        # macOS
 ```
 
-### uv Installation Issues
+### uv not found
 
 **Problem**: `command not found: uv`
 
-**Solution**:
-```bash
-# Install uv
-curl -LsSf https://astral.sh/uv/install.sh | sh
+**Solution**: Install uv using the [official installation guide](https://docs.astral.sh/uv/getting-started/installation/).
 
-# Alternative methods
-pip install uv
-brew install uv  # macOS
-```
+### ssdl not found
 
-**Problem**: Permission denied during installation
+**Problem**: `command not found: ssdl` after `uv tool install ssdownload`
 
 **Solution**:
-```bash
-# Use user installation
-pip install --user uv
 
-# Or use virtual environment
-python -m venv venv
-source venv/bin/activate
-pip install uv
+```bash
+uv tool update-shell
 ```
+
+Open a new terminal. Confirm the executable directory:
+
+```bash
+uv tool dir --bin
+```
+
+That directory must be on your `PATH` (on Windows, often `%USERPROFILE%\.local\bin`).
 
 ### Dependency Conflicts
 


### PR DESCRIPTION
## Summary

- Make `uv tool install ssdownload` the primary installation path in README and a simplified INSTALLATION.md
- Remove outdated guidance (`uvx` quick start, "not yet on PyPI", verbose clone-first flow)
- Align CLI_REFERENCE, EXAMPLES, DEVELOPMENT, and TROUBLESHOOTING terminology; defer uv installation to official docs
- Update GitHub Release notes to recommend `uv tool install ssdownload==<tag>` for CLI installs

## Test plan

- [x] Pre-commit hooks passed on commit
- [ ] Review README Quick Start and INSTALLATION.md for clarity
- [ ] Confirm release.yml Installation block renders correctly on next release