### PR TITLE
feat: add square and rectangle filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ Added
+- Added `--square` and `--rectangle` filters to `ssdl list` and `ssdl bulk`
+- Added `Filter(square=True|False)` for square and rectangular matrix filtering
+
 ## [0.2.0] - 2026-06-06
 
 ### 🔄 Changed

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ ssdl download ct20stif --format mm
 # Search matrices with filters
 ssdl list --spd --size 1000:10000 --field real
 
+# Search square unsymmetric matrices
+ssdl list --square --structure unsymmetric
+
 # Bulk download (real) SPD matrices in size range
 ssdl bulk --spd --field real --size 100:1000 --max-files 5
 ```
@@ -60,6 +63,9 @@ path = await downloader.download_by_name("ct20stif")
 # Filtered bulk download
 filter_obj = Filter(spd=True, n_rows=(1000, 10000))
 paths = await downloader.bulk_download(filter_obj, max_files=5)
+
+# Find rectangular matrices
+rectangular = await downloader.find_matrices(Filter(square=False))
 ```
 
 </details>

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -194,12 +194,14 @@ Filter(
     group: Optional[str] = None,
     name: Optional[str] = None,
     kind: Optional[str] = None,
-    structure: Optional[str] = None
+    structure: Optional[str] = None,
+    square: Optional[bool] = None
 )
 ```
 
 **Parameters:**
 - `spd` - Symmetric positive definite flag
+- `square` - `True` for square matrices or `False` for rectangular matrices
 - `n_rows` - Row count range (min, max)
 - `n_cols` - Column count range (min, max)
 - `nnz` - Non-zero count range (min, max)
@@ -222,6 +224,9 @@ filter3 = Filter(n_rows=(100000, None), nnz=(None, 1000000))
 
 # Search by name pattern
 filter4 = Filter(name="stif")
+
+# Rectangular matrices
+filter5 = Filter(square=False)
 ```
 
 ## Exception Handling

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -105,6 +105,9 @@ ssdl bulk [FILTER_OPTIONS] [OPTIONS]
 # Download SPD matrices
 ssdl bulk --spd --max-files 10
 
+# Download rectangular matrices
+ssdl bulk --rectangle --max-files 10
+
 # Download small to medium matrices in Matrix Market format
 ssdl bulk --size 1000:50000 --format mm --output ./matrices
 
@@ -139,6 +142,9 @@ ssdl list --name "stif" --verbose
 
 # List SPD matrices with size constraints
 ssdl list --spd --size 1000:10000 --field real
+
+# List square unsymmetric matrices
+ssdl list --square --structure unsymmetric
 ```
 
 ### `ssdl info`
@@ -173,8 +179,12 @@ These filters can be used with `bulk` and `list` commands:
 
 ### Matrix Properties
 - `--spd` - Symmetric positive definite matrices only (automatically filters for symmetric AND positive definite AND square matrices)
+- `--square` - Square matrices only (rows equal columns)
+- `--rectangle` - Rectangular matrices only (rows differ from columns)
 - `--field TYPE` - Field type: `real`, `complex`, `integer`, `binary`
 - `--structure TYPE` - Matrix structure: `symmetric`, `unsymmetric`, etc.
+
+`--square` and `--rectangle` cannot be used together.
 
 ### Size Filters
 - `--size MIN:MAX` - Matrix size range (applies to both rows and columns)

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -64,6 +64,9 @@ ssdl list --size 1000:10000 --limit 5
 # Search SPD matrices
 ssdl list --spd --field real --verbose
 
+# Search square unsymmetric matrices
+ssdl list --square --structure unsymmetric
+
 # Search by name pattern
 ssdl list --name "stif" --limit 3
 ```
@@ -82,6 +85,9 @@ uv run ssdl list --size 1000:10000 --limit 5
 # Search SPD matrices
 uv run ssdl list --spd --field real --verbose
 
+# Search rectangular matrices
+uv run ssdl list --rectangle --verbose
+
 # Search by name pattern
 uv run ssdl list --name "stif" --limit 3
 ```
@@ -92,6 +98,9 @@ uv run ssdl list --name "stif" --limit 3
 ```bash
 # Download SPD matrices
 ssdl bulk --spd --max-files 5
+
+# Download rectangular matrices
+ssdl bulk --rectangle --max-files 5
 
 # Download by size range in Matrix Market format
 ssdl bulk --size 1000:5000 --format mm --max-files 10

--- a/src/ssdownload/cli.py
+++ b/src/ssdownload/cli.py
@@ -26,6 +26,15 @@ app = typer.Typer(
 console = Console()
 
 
+def _build_filter_or_exit(**kwargs: Any) -> Filter | None:
+    """Build a filter and report invalid CLI filter combinations."""
+    try:
+        return build_filter(**kwargs)
+    except ValueError as e:
+        console.print(f"✗ Error: {e}", style="red")
+        raise typer.Exit(2) from e
+
+
 @app.command()
 def download(
     identifier: str = typer.Argument(..., help="Matrix name or group/name"),
@@ -143,6 +152,10 @@ def bulk(
     spd: bool = typer.Option(
         False, "--spd", help="Symmetric positive definite matrices only"
     ),
+    square: bool = typer.Option(False, "--square", help="Square matrices only"),
+    rectangle: bool = typer.Option(
+        False, "--rectangle", help="Rectangular matrices only"
+    ),
     size: str | None = typer.Option(
         None, "--size", help="Matrix size range (e.g., '1000:5000')"
     ),
@@ -208,8 +221,10 @@ def bulk(
 ):
     """Download multiple matrices matching filter criteria."""
     # Build filter
-    filter_obj = build_filter(
+    filter_obj = _build_filter_or_exit(
         spd=spd,
+        square=square,
+        rectangle=rectangle,
         size=size,
         rows=rows,
         cols=cols,
@@ -268,6 +283,10 @@ def list(
     spd: bool = typer.Option(
         False, "--spd", help="Symmetric positive definite matrices only"
     ),
+    square: bool = typer.Option(False, "--square", help="Square matrices only"),
+    rectangle: bool = typer.Option(
+        False, "--rectangle", help="Rectangular matrices only"
+    ),
     size: str | None = typer.Option(
         None, "--size", help="Matrix size range (e.g., '1000:5000')"
     ),
@@ -316,8 +335,10 @@ def list(
 ):
     """List matrices matching filter criteria."""
     # Build filter
-    filter_obj = build_filter(
+    filter_obj = _build_filter_or_exit(
         spd=spd,
+        square=square,
+        rectangle=rectangle,
         size=size,
         rows=rows,
         cols=cols,

--- a/src/ssdownload/cli_utils.py
+++ b/src/ssdownload/cli_utils.py
@@ -110,12 +110,21 @@ def build_filter(
     num_dmperm_blocks: str | None = None,
     structural_rank: str | None = None,
     cholesky_candidate: bool | None = None,
+    square: bool = False,
+    rectangle: bool = False,
 ) -> Filter | None:
     """Build a Filter object from CLI arguments."""
     filter_kwargs: dict[str, Any] = {}
 
+    if square and rectangle:
+        raise ValueError("--square and --rectangle cannot be used together")
+
     if spd:
         filter_kwargs["spd"] = True
+    if square:
+        filter_kwargs["square"] = True
+    elif rectangle:
+        filter_kwargs["square"] = False
     if field:
         filter_kwargs["field"] = field
     if group:

--- a/src/ssdownload/filters.py
+++ b/src/ssdownload/filters.py
@@ -10,6 +10,7 @@ class Filter:
 
     Attributes:
         spd: Filter for symmetric positive definite matrices
+        square: Filter for square (True) or rectangular (False) matrices
         n_rows: Tuple of (min, max) for number of rows
         n_cols: Tuple of (min, max) for number of columns
         nnz: Tuple of (min, max) for number of nonzeros
@@ -47,6 +48,7 @@ class Filter:
     num_dmperm_blocks: tuple[int | None, int | None] | None = None
     structural_rank: tuple[int | None, int | None] | None = None
     cholesky_candidate: bool | None = None
+    square: bool | None = None
 
     def matches(self, matrix_info: dict[str, Any]) -> bool:
         """Check if a matrix matches this filter.
@@ -73,6 +75,13 @@ class Filter:
         # Check positive definite flag
         if self.posdef is not None and matrix_info.get("posdef") != self.posdef:
             return False
+
+        # Check matrix shape
+        if self.square is not None:
+            rows = matrix_info.get("num_rows", matrix_info.get("rows"))
+            cols = matrix_info.get("num_cols", matrix_info.get("cols"))
+            if rows is None or cols is None or (rows == cols) != self.square:
+                return False
 
         # Check number of rows
         if self.n_rows is not None:
@@ -221,6 +230,9 @@ class Filter:
 
         if self.posdef is not None:
             result["posdef"] = self.posdef
+
+        if self.square is not None:
+            result["square"] = self.square
 
         if self.n_rows is not None:
             result["n_rows"] = self.n_rows

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,9 @@
+"""Shared test helpers."""
+
+from click import unstyle
+from click.testing import Result
+
+
+def plain_output(result: Result) -> str:
+    """Return CLI output without ANSI styling."""
+    return unstyle(result.stdout)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 
 from ssdownload.cli import app
 from ssdownload.cli_utils import parse_range
+from tests.helpers import plain_output
 
 
 class TestCLI:
@@ -284,11 +285,12 @@ class TestCLI:
     def test_shape_options_are_shown_in_filter_command_help(self):
         """List and bulk help should expose both shape filters."""
         for command in ("list", "bulk"):
-            result = self.runner.invoke(app, [command, "--help"])
+            result = self.runner.invoke(app, [command, "--help"], color=True)
+            output = plain_output(result)
 
             assert result.exit_code == 0
-            assert "--square" in result.stdout
-            assert "--rectangle" in result.stdout
+            assert "--square" in output
+            assert "--rectangle" in output
 
     @patch("ssdownload.cli.SuiteSparseDownloader")
     def test_list_square_filter(self, mock_downloader_class):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -281,6 +281,49 @@ class TestCLI:
             assert result.exit_code == 0
             assert len(result.stdout) > 50  # Should have substantial help text
 
+    def test_shape_options_are_shown_in_filter_command_help(self):
+        """List and bulk help should expose both shape filters."""
+        for command in ("list", "bulk"):
+            result = self.runner.invoke(app, [command, "--help"])
+
+            assert result.exit_code == 0
+            assert "--square" in result.stdout
+            assert "--rectangle" in result.stdout
+
+    @patch("ssdownload.cli.SuiteSparseDownloader")
+    def test_list_square_filter(self, mock_downloader_class):
+        """List should pass a square filter to the downloader."""
+        mock_downloader = MagicMock()
+        mock_downloader.list_matrices.return_value = ([], 0)
+        mock_downloader_class.return_value = mock_downloader
+
+        result = self.runner.invoke(app, ["list", "--square"])
+
+        assert result.exit_code == 0
+        filter_obj = mock_downloader.list_matrices.call_args.args[0]
+        assert filter_obj.square is True
+
+    @patch("ssdownload.cli.SuiteSparseDownloader")
+    def test_bulk_rectangle_filter(self, mock_downloader_class):
+        """Bulk should pass a rectangular filter to the download workflow."""
+        mock_downloader = MagicMock()
+        mock_downloader.bulk_download = AsyncMock(return_value=[])
+        mock_downloader_class.return_value = mock_downloader
+
+        result = self.runner.invoke(app, ["bulk", "--rectangle"])
+
+        assert result.exit_code == 0
+        filter_obj = mock_downloader.bulk_download.await_args.args[0]
+        assert filter_obj.square is False
+
+    def test_shape_options_are_mutually_exclusive(self):
+        """Commands should clearly reject conflicting shape filters."""
+        for command in ("list", "bulk"):
+            result = self.runner.invoke(app, [command, "--square", "--rectangle"])
+
+            assert result.exit_code == 2
+            assert "--square and --rectangle cannot be used together" in result.stdout
+
     @patch("ssdownload.cli.Config.get_default_cache_dir")
     def test_clean_cache_no_cache_file(self, mock_cache_dir):
         """Test clean-cache command when no cache file exists."""

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,5 +1,7 @@
 """Tests for cli_utils module."""
 
+import pytest
+
 from ssdownload.cli_utils import build_filter, parse_range
 from ssdownload.filters import Filter
 
@@ -49,6 +51,25 @@ class TestCliUtils:
         assert result.spd is True
         assert result.posdef is None
 
+    def test_build_filter_square(self):
+        """Test building a square matrix filter."""
+        result = build_filter(square=True)
+        assert isinstance(result, Filter)
+        assert result.square is True
+
+    def test_build_filter_rectangle(self):
+        """Test building a rectangular matrix filter."""
+        result = build_filter(rectangle=True)
+        assert isinstance(result, Filter)
+        assert result.square is False
+
+    def test_build_filter_rejects_conflicting_shape_flags(self):
+        """Square and rectangle flags should be mutually exclusive."""
+        with pytest.raises(
+            ValueError, match="--square and --rectangle cannot be used together"
+        ):
+            build_filter(square=True, rectangle=True)
+
     def test_build_filter_string_fields(self):
         """Test building filter with string fields."""
         result = build_filter(
@@ -97,6 +118,7 @@ class TestCliUtils:
         """Test building filter with all parameters."""
         result = build_filter(
             spd=True,
+            square=True,
             size="1000:5000",
             rows="2000:3000",
             cols="4000:6000",
@@ -109,6 +131,7 @@ class TestCliUtils:
         )
         assert isinstance(result, Filter)
         assert result.spd is True
+        assert result.square is True
         assert result.n_rows == (2000, 3000)  # Should override size
         assert result.n_cols == (4000, 6000)  # Should override size
         assert result.nnz == (None, 1000000)

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -56,6 +56,30 @@ class TestFilter:
         }
         assert not filter_obj.matches(non_square)
 
+    def test_square_filter(self):
+        """Square filters should compare row and column counts."""
+        filter_obj = Filter(square=True)
+
+        assert filter_obj.matches({"num_rows": 100, "num_cols": 100})
+        assert not filter_obj.matches({"num_rows": 100, "num_cols": 200})
+
+    def test_rectangle_filter(self):
+        """Rectangular filters should require different row and column counts."""
+        filter_obj = Filter(square=False)
+
+        assert filter_obj.matches({"num_rows": 100, "num_cols": 200})
+        assert not filter_obj.matches({"num_rows": 100, "num_cols": 100})
+
+    def test_shape_filter_alternative_field_names(self):
+        """Shape filters should support CSV row and column field names."""
+        assert Filter(square=True).matches({"rows": 100, "cols": 100})
+        assert Filter(square=False).matches({"rows": 100, "cols": 200})
+
+    def test_shape_filter_missing_dimensions(self):
+        """Shape filters should reject matrices with incomplete dimensions."""
+        assert not Filter(square=True).matches({"num_rows": 100})
+        assert not Filter(square=False).matches({"num_cols": 100})
+
     def test_size_range_filter(self):
         """Test size range filtering."""
         filter_obj = Filter(n_rows=(100, 1000))
@@ -154,17 +178,20 @@ class TestFilter:
         """Test conversion to dictionary."""
         filter_obj = Filter(
             spd=True,
+            square=True,
             n_rows=(100, 1000),
             field="real",
         )
 
         expected = {
             "spd": True,
+            "square": True,
             "n_rows": (100, 1000),
             "field": "real",
         }
 
         assert filter_obj.to_dict() == expected
+        assert Filter(square=False).to_dict() == {"square": False}
 
     def test_missing_fields_dont_match(self):
         """Test that missing fields in matrix info don't cause matches."""


### PR DESCRIPTION
## Summary

- Add `--square` and `--rectangle` to `ssdl list`
- Add `--square` and `--rectangle` to `ssdl bulk`
- Add `Filter(square=True|False)`
- Reject simultaneous use of both CLI options

## Type of Change

<!-- Mark relevant options with [x] -->
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update

## Related Issues

Closes #24 
